### PR TITLE
silence sprintf deprecated warnings and enable imwri in macos build

### DIFF
--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -11,7 +11,7 @@ jobs:
       CXX: clang++
 
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
 
     - name: Print compiler version
       run: ${{ env.CC }} --version
@@ -19,7 +19,7 @@ jobs:
     - name: Install autotools
       run: |
         brew update
-        brew install automake autoconf libtool pkg-config
+        brew install automake autoconf libtool pkg-config llvm
 
     - name: Install zimg
       run: |
@@ -33,7 +33,7 @@ jobs:
         rm -rf zimg
 
     - name: Setup Python
-      uses: actions/setup-python@v4
+      uses: actions/setup-python@v5
       with:
         # Version range or exact version of a Python version to use, using SemVer's version range syntax.
         python-version: 3.9
@@ -48,12 +48,10 @@ jobs:
 
     - name: configure
       run: |
+        export CC=/opt/homebrew/opt/llvm/bin/clang
+        export CXX=/opt/homebrew/opt/llvm/bin/clang++
         ./autogen.sh
-        # somehow newer macOS imagemagick requires -fopenmp to build?
-        ./configure --disable-imwri
-
-    - name: make
-      run: make -j3
+        ./configure
 
     - name: make install
       run: |
@@ -62,3 +60,5 @@ jobs:
 
     - name: Run test
       run: python -m unittest discover -s test -p "*test.py"
+
+    

--- a/src/core/vscore.cpp
+++ b/src/core/vscore.cpp
@@ -1493,7 +1493,7 @@ const vs3::VSVideoFormat *VSCore::queryVideoFormat3(vs3::VSColorFamily colorFami
         if (sampleType == stFloat)
             strcpy(suffix, (bitsPerSample == 32) ? "S" : "H");
         else
-            sprintf(suffix, "%d", (colorFamily == vs3::cmRGB ? 3:1) * bitsPerSample);
+            snprintf(suffix, sizeof(suffix), "%d", (colorFamily == vs3::cmRGB ? 3 : 1) * bitsPerSample);
 
         const char *yuvName = nullptr;
 
@@ -1853,7 +1853,7 @@ bool VSCore::getVideoFormatName(const VSVideoFormat &format, char *buffer) noexc
     if (format.sampleType == stFloat)
         strcpy(suffix, (format.bitsPerSample == 32) ? "S" : "H");
     else
-        sprintf(suffix, "%d", (format.colorFamily == cfRGB ? 3:1) * format.bitsPerSample);
+        snprintf(suffix, sizeof(suffix), "%d", (format.colorFamily == cfRGB ? 3 : 1) * format.bitsPerSample);
 
     const char *yuvName = nullptr;
 


### PR DESCRIPTION
MacOS clang compiler complains about 

```
src/core/vscore.cpp:1496:13: warning: 'sprintf' is deprecated: This function is provided for compatibility reasons only.  Due to security concerns inherent in the design of sprintf(3), it is highly recommended that you use snprintf(3) instead. [-Wdeprecated-declarations]
 1496 |             sprintf(suffix, "%d", (colorFamily == vs3::cmRGB ? 3:1) * bitsPerSample);
      |             ^
/Library/Developer/CommandLineTools/SDKs/MacOSX14.sdk/usr/include/stdio.h:180:1: note: 'sprintf' has been explicitly marked deprecated here
  180 | __deprecated_msg("This function is provided for compatibility reasons only.  Due to security concerns inherent in the design of sprintf(3), it is highly recommended that you use snprintf(3) instead.")
      | ^
/Library/Developer/CommandLineTools/SDKs/MacOSX14.sdk/usr/include/sys/cdefs.h:[21](https://github.com/yuygfgg/vapoursynth-classic/actions/runs/10958658371/job/30429337951#step:10:22)8:48: note: expanded from macro '__deprecated_msg'
  218 |         #define __deprecated_msg(_msg) __attribute__((__deprecated__(_msg)))
      |                                                       ^
src/core/vscore.cpp:1856:9: warning: 'sprintf' is deprecated: This function is provided for compatibility reasons only.  Due to security concerns inherent in the design of sprintf(3), it is highly recommended that you use snprintf(3) instead. [-Wdeprecated-declarations]
 1856 |         sprintf(suffix, "%d", (format.colorFamily == cfRGB ? 3:1) * format.bitsPerSample);
      |         ^
/Library/Developer/CommandLineTools/SDKs/MacOSX14.sdk/usr/include/stdio.h:180:1: note: 'sprintf' has been explicitly marked deprecated here
  180 | __deprecated_msg("This function is provided for compatibility reasons only.  Due to security concerns inherent in the design of sprintf(3), it is highly recommended that you use snprintf(3) instead.")
      | ^
/Library/Developer/CommandLineTools/SDKs/MacOSX14.sdk/usr/include/sys/cdefs.h:218:48: note: expanded from macro '__deprecated_msg'
  218 |         #define __deprecated_msg(_msg) __attribute__((__deprecated__(_msg)))
```